### PR TITLE
Use a less prone to colision name for the repo generated out maven.install

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -72,6 +72,7 @@ use_repo(crate, crate_index = "crates")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
+    name = "protobuf_maven",
     artifacts = [
         "com.google.caliper:caliper:1.0-beta-3",
         "com.google.code.findbugs:jsr305:3.0.2",
@@ -91,7 +92,7 @@ maven.install(
         "https://repo.maven.apache.org/maven2",
     ],
 )
-use_repo(maven, "maven")
+use_repo(maven, "protobuf_maven")
 
 # Development dependencies
 bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,6 +63,7 @@ rules_jvm_external_setup()
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
+    name = "protobuf_maven",
     artifacts = PROTOBUF_MAVEN_ARTIFACTS,
     # For updating instructions, see:
     # https://github.com/bazelbuild/rules_jvm_external#updating-maven_installjson
@@ -73,7 +74,7 @@ maven_install(
     ],
 )
 
-load("@maven//:defs.bzl", "pinned_maven_install")
+load("@protobuf_maven//:defs.bzl", "pinned_maven_install")
 
 pinned_maven_install()
 

--- a/java/core/BUILD.bazel
+++ b/java/core/BUILD.bazel
@@ -389,8 +389,8 @@ protobuf_java_library(
         ":generic_test_protos_java_proto",
         ":java_test_protos_java_proto",
         ":lite_test_protos_java_proto",
-        "@maven//:com_google_guava_guava",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 
@@ -440,10 +440,10 @@ junit_tests(
         ":java_test_protos_java_proto",
         ":lite_test_protos_java_proto",
         ":test_util",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_mockito_mockito_core",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
+        "@protobuf_maven//:org_mockito_mockito_core",
     ],
 )
 
@@ -459,9 +459,9 @@ junit_tests(
     ],
     deps = [
         ":core",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 
@@ -516,8 +516,8 @@ protobuf_java_library(
         ":java_test_protos_java_proto_lite",
         ":lite_runtime_only",
         ":lite_test_protos_java_proto_lite",
-        "@maven//:com_google_guava_guava",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 
@@ -584,9 +584,9 @@ junit_tests(
         ":lite",
         ":lite_test_protos_java_proto_lite",
         ":test_util_lite",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_mockito_mockito_core",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
+        "@protobuf_maven//:org_mockito_mockito_core",
     ],
 )
 
@@ -600,8 +600,8 @@ protobuf_java_library(
     deps = [
         ":core",
         "//compatibility:v25_test_protos_srcjar",
-        "@maven//:com_google_guava_guava",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 
@@ -631,10 +631,10 @@ junit_tests(
         ":core",
         ":v25_test_util_srcjar",
         "//compatibility:v25_test_protos_srcjar",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_mockito_mockito_core",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
+        "@protobuf_maven//:org_mockito_mockito_core",
     ],
 )
 
@@ -648,8 +648,8 @@ protobuf_java_library(
     deps = [
         ":core",
         "//compatibility:v25_test_protos_jar",
-        "@maven//:com_google_guava_guava",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 
@@ -679,10 +679,10 @@ junit_tests(
         ":core",
         ":v25_test_util_jar",
         "//compatibility:v25_test_protos_jar",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_mockito_mockito_core",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
+        "@protobuf_maven//:org_mockito_mockito_core",
     ],
 )
 

--- a/java/internal/BUILD.bazel
+++ b/java/internal/BUILD.bazel
@@ -18,7 +18,7 @@ java_test(
     srcs = ["JavaVersionTest.java"],
     test_class = "JavaVersionTest",
     deps = [
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
     ],
 )

--- a/java/kotlin-lite/BUILD.bazel
+++ b/java/kotlin-lite/BUILD.bazel
@@ -99,8 +99,8 @@ kt_jvm_library(
         "//java/kotlin:only_for_use_in_proto_generated_code_its_generator_and_tests",
         "//java/kotlin:shared_runtime",
         "//java/lite",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
         "@rules_kotlin//kotlin/compiler:kotlin-test",
     ],
 )
@@ -195,8 +195,8 @@ kt_jvm_library(
     deps = [
         ":kotlin_unittest_lite",
         "//java/core:test_util_lite",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 
@@ -212,8 +212,8 @@ kt_jvm_library(
     deps = [
         ":kotlin_proto3_unittest_lite",
         "//java/core:test_util_lite",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 

--- a/java/kotlin/BUILD.bazel
+++ b/java/kotlin/BUILD.bazel
@@ -101,8 +101,8 @@ kt_jvm_library(
     deps = [
         ":bytestring_lib",
         "//java/lite",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
         "@rules_kotlin//kotlin/compiler:kotlin-test",
     ],
 )
@@ -136,9 +136,9 @@ kt_jvm_library(
         ":example_extensible_message_java_proto",
         ":only_for_use_in_proto_generated_code_its_generator_and_tests",
         ":shared_runtime",
-        "@maven//:com_google_guava_guava_testlib",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_guava_guava_testlib",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
         "@rules_kotlin//kotlin/compiler:kotlin-test",
     ],
 )
@@ -162,8 +162,8 @@ kt_jvm_library(
         ":only_for_use_in_proto_generated_code_its_generator_and_tests",
         ":shared_runtime",
         "//java/core",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
         "@rules_kotlin//kotlin/compiler:kotlin-test",
     ],
 )
@@ -274,8 +274,8 @@ kt_jvm_library(
     deps = [
         ":kotlin_unittest",
         "//java/core:test_util",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
         "@rules_kotlin//kotlin/compiler:kotlin-reflect",
     ],
 )
@@ -292,8 +292,8 @@ kt_jvm_library(
     deps = [
         ":kotlin_proto3_unittest",
         "//java/core:test_util",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 

--- a/java/lite/BUILD.bazel
+++ b/java/lite/BUILD.bazel
@@ -76,8 +76,8 @@ junit_tests(
         "//java/core:java_test_protos_java_proto_lite",
         "//java/core:lite_test_protos_java_proto_lite",
         "//java/core:test_util_lite",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 

--- a/java/osgi/BUILD.bazel
+++ b/java/osgi/BUILD.bazel
@@ -9,8 +9,8 @@ java_binary(
     srcs = ["OsgiWrapper.java"],
     main_class = "com.google.protobuf.osgi.OsgiWrapper",
     deps = [
-        "@maven//:biz_aQute_bnd_biz_aQute_bndlib",
-        "@maven//:com_google_guava_guava",
-        "@maven//:info_picocli_picocli",
+        "@protobuf_maven//:biz_aQute_bnd_biz_aQute_bndlib",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:info_picocli_picocli",
     ],
 )

--- a/java/util/BUILD.bazel
+++ b/java/util/BUILD.bazel
@@ -13,11 +13,11 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//java/core",
-        "@maven//:com_google_code_findbugs_jsr305",
-        "@maven//:com_google_code_gson_gson",
-        "@maven//:com_google_errorprone_error_prone_annotations",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_j2objc_j2objc_annotations",
+        "@protobuf_maven//:com_google_code_findbugs_jsr305",
+        "@protobuf_maven//:com_google_code_gson_gson",
+        "@protobuf_maven//:com_google_errorprone_error_prone_annotations",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:com_google_j2objc_j2objc_annotations",
     ],
 )
 
@@ -33,11 +33,11 @@ protobuf_versioned_java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//java/core",
-        "@maven//:com_google_code_findbugs_jsr305",
-        "@maven//:com_google_code_gson_gson",
-        "@maven//:com_google_errorprone_error_prone_annotations",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_j2objc_j2objc_annotations",
+        "@protobuf_maven//:com_google_code_findbugs_jsr305",
+        "@protobuf_maven//:com_google_code_gson_gson",
+        "@protobuf_maven//:com_google_errorprone_error_prone_annotations",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:com_google_j2objc_j2objc_annotations",
     ],
 )
 
@@ -90,10 +90,10 @@ junit_tests(
         ":util",
         "//java/core",
         "//java/core:generic_test_protos_java_proto",
-        "@maven//:com_google_code_gson_gson",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
+        "@protobuf_maven//:com_google_code_gson_gson",
+        "@protobuf_maven//:com_google_guava_guava",
+        "@protobuf_maven//:com_google_truth_truth",
+        "@protobuf_maven//:junit_junit",
     ],
 )
 


### PR DESCRIPTION
When using this module in other modules we errors when the rool project
also uses `maven` and don't specify its own specfic name.

```
DEBUG:
$TMP/external/rules_jvm_external~/private/extensions/maven.bzl:154:14:
The maven repository 'maven' is used in two different bazel modules,
    originally in '<my_workspace>' and now in 'protobuf'
``
